### PR TITLE
Refactor observer pattern for parameterized notifications

### DIFF
--- a/Controller/Controller.cpp
+++ b/Controller/Controller.cpp
@@ -14,9 +14,7 @@ void Controller::init() {
             "Unknown Author",       
             "No Plot"               
             );
-        mQuery.clear(); // azzera il filtro
-        pView->showEditForm(newBook, true);
-        notifyAll();
+		pView->showEditForm(newBook, true);
     });
 
     
@@ -29,9 +27,7 @@ void Controller::init() {
             "No Plot",              //TRAMA
             90                      
             );
-        mQuery.clear();
         pView->showEditForm(newFilm, true);
-        notifyAll();
     });
 
     
@@ -44,43 +40,34 @@ void Controller::init() {
             "Pop",                  // Genere
             10                      
             );
-        mQuery.clear();
         pView->showEditForm(newAlbum, true);
-        notifyAll();
     });
 
     
     QObject::connect(pView.get(), &View::newMediaCreated, this, [this](const MediaPtr& media) {
         pModel->addMedia(media);
-        notifyAll();
     });
 
     
     QObject::connect(pView.get(), &View::loadButtonClicked, this, [this](const QString& filepath) {
         XMLSerializer xml;
         xml.load(filepath, *pModel);
-        mQuery.clear();
-        notifyAll();
     });
     QObject::connect(pView.get(), &View::saveButtonClicked, this, [this](const QString& filepath) {
         XMLSerializer xml;
         xml.save(filepath, *pModel);
     });
 
-    // Quando viene emesso il segnale searchButtonClicked, il Controller aggiorna mQuery e chiama notifyAll()
     QObject::connect(pView.get(), &View::searchButtonClicked, this, [this](const QString& query) {
-        mQuery = query;
-        notifyAll();
+		pModel->search(query);
+
     });
-    // Il tasto reset cancella mQuery e chiama notifyAll()
     QObject::connect(pView.get(), &View::resetButtonClicked, this, [this]() {
-        mQuery.clear();
-        notifyAll();
+		pModel->search("");
     });
 
     
     QObject::connect(pView.get(), &View::removeMedia, this, [this](const MediaPtr& media) {
         pModel->removeMedia(media);
-        notifyAll();
     });
 }

--- a/Controller/Controller.h
+++ b/Controller/Controller.h
@@ -6,7 +6,7 @@
 #include <QtCore/QObject>
 
 
-class Controller: public QObject, public Observer, public Subject {
+class Controller: public QObject {
     Q_OBJECT
 public:
     Controller(ModelPtr model, ViewPtr view)
@@ -15,22 +15,7 @@ public:
 
     void init();
 
-protected:
-    
-    virtual void notifyAll() override {
-        
-        for (Observer* observer : mObservers) {
-            if (observer != this) {
-                observer->update(&mQuery);
-            }
-        }
-    }
-
-    
-    virtual void update(void* data) override { (void)data; }
-
 private:
     ModelPtr pModel;
     ViewPtr pView;
-    QString mQuery;
 };

--- a/Model/Biblioteca.cpp
+++ b/Model/Biblioteca.cpp
@@ -3,28 +3,29 @@
 void Biblioteca::addMedia(const MediaPtr& media) {
 	media->registerObserver(this);
 	mMedia.push_back(media);
-	notifyAll();
+	notifyAll({ mMedia });
 }
 
 void Biblioteca::removeMedia(const MediaPtr& media) {
 	const auto& it = std::find(mMedia.begin(), mMedia.end(), media);
 	if (it != mMedia.end()) {
 		mMedia.erase(it);
-		notifyAll();
+		notifyAll({ mMedia });
 	}
 }
 
-std::vector<MediaPtr> Biblioteca::search(const QString& s) const {
-	std::vector<MediaPtr> v;
-    for (MediaPtr media : mMedia)
+std::vector<MediaPtr> Biblioteca::search(const QString& s) {
+	std::vector<MediaPtr> result;
+	for (MediaPtr media : mMedia)
 		if (media->mathes(s))
-			v.push_back(media);
+			result.push_back(media);
 
-	return v;
+	notifyAll({ result, s });
+
+	return result;
 }
 
 void Biblioteca::clear() {
-	mMedia.erase(mMedia.begin(), mMedia.end());
-	notifyAll();
+	mMedia.clear();
+    notifyAll({ mMedia });
 }
-

--- a/Model/Biblioteca.h
+++ b/Model/Biblioteca.h
@@ -6,25 +6,29 @@
 #include "Observer.h"
 #include "Media.h"
 
-using MediaPtr = std::shared_ptr<Media>;
-
 class Biblioteca;
 using Model = Biblioteca;
 using ModelPtr = std::shared_ptr<Model>;
 
-class Biblioteca: public Subject, public Observer {
+
+struct ModelData {
+	const std::vector<MediaPtr> medias;
+	const QString& query { };
+};
+
+class Biblioteca: public Subject<ModelData>, public ObserverNoParameters {
 
 	public:
 
 		void addMedia(const MediaPtr& media);
 		void removeMedia(const MediaPtr& media);
 
-		std::vector<MediaPtr> search(const QString& s) const;
+        std::vector<MediaPtr> search(const QString& s);
 		
 		void clear();
 
         const std::vector<MediaPtr> media() const { return mMedia; }
-		void setMedia(const std::vector<MediaPtr>& media) { mMedia = media; notifyAll();  }
+		void setMedia(const std::vector<MediaPtr>& media) { mMedia = media; notifyAll({ mMedia });  }
 
 		auto begin() { return mMedia.begin(); }
 		auto end() { return mMedia.end(); }
@@ -34,12 +38,7 @@ class Biblioteca: public Subject, public Observer {
 
 	protected:
 
-		virtual void notifyAll() override {
-			for (Observer* observer : mObservers)
-				observer->update(nullptr);
-		}
-
-        virtual void update(void*) override { notifyAll(); }
+        virtual void update() override { notifyAll({ mMedia }); }
 
 
 	private:

--- a/Model/Media.h
+++ b/Model/Media.h
@@ -1,11 +1,15 @@
 #pragma once
 
 #include "Observer.h"
+#include <memory>
 #include <QtCore/QString>
 
 class Visitor;
+class Media;
 
-class Media: public Subject {
+using MediaPtr = std::shared_ptr<Media>;
+
+class Media: public SubjectNoParameters {
 
 	public:
 
@@ -31,14 +35,6 @@ class Media: public Subject {
 				notifyAll();
 				mDirty = false;
 			}
-		}
-
-
-	protected:
-
-		virtual void notifyAll() override {
-			for (Observer* observer : mObservers)
-				observer->update(nullptr);
 		}
 
 

--- a/Model/Observer.h
+++ b/Model/Observer.h
@@ -1,31 +1,34 @@
 #pragma once
-
 #include <memory>
 #include <vector>
 #include <algorithm>
 
+template <class T>
 class Observer {
-	
+
 	public:
 
 		virtual ~Observer() = default;
-		
-		virtual void update(void* data) = 0;
+
+		virtual void update(const T& data) = 0;
 
 };
 
-
+template <class T>
 class Subject {
-	
-	public:
 
+	public:
+		
 		virtual ~Subject() = default;
-	
-		void registerObserver(Observer* observer) {
+
+		void registerObserver(Observer<T>* observer) {
+			if (observer == nullptr)
+				return;
+
 			mObservers.push_back(observer);
 		}
 
-		void removeObserver(Observer* observer) {
+		void removeObserver(Observer<T>* observer) {
 			mObservers.erase(
 				std::remove(mObservers.begin(), mObservers.end(), observer),
 				mObservers.end()
@@ -35,11 +38,62 @@ class Subject {
 
 	protected:
 
-		virtual void notifyAll() = 0;
+		virtual void notifyAll(const T& data) {
+			for (const auto& observer : mObservers)
+				observer->update(data);
+		}
 
-
-	protected:
 		
-		std::vector<Observer*> mObservers;
+	protected:
+
+		std::vector<Observer<T>*> mObservers;
 
 };
+
+
+
+template <>
+class Observer<void> {
+	public:
+
+		virtual ~Observer() = default;
+
+		virtual void update() = 0;
+};
+
+template <>
+class Subject<void> {
+
+	public:
+
+		virtual ~Subject() = default;
+
+		void registerObserver(Observer<void>* observer) {
+			if (observer == nullptr)
+				return;
+
+			mObservers.push_back(observer);
+		}
+
+		void removeObserver(Observer<void>* observer) {
+			mObservers.erase(
+				std::remove(mObservers.begin(), mObservers.end(), observer),
+				mObservers.end()
+			);
+		}
+
+	protected:
+
+		virtual void notifyAll() {
+			for (auto observer : mObservers)
+				observer->update();
+		}
+
+	protected:
+
+		std::vector<Observer<void>*> mObservers;
+
+};
+
+using SubjectNoParameters = Subject<void>;
+using ObserverNoParameters = Observer<void>;

--- a/View/View.h
+++ b/View/View.h
@@ -12,19 +12,13 @@
 
 class View;
 using ViewPtr = std::shared_ptr<View>;
-using ConstViewPtr = std::shared_ptr<const View>;
 
-class View: public QMainWindow, public Observer {
+class View: public QMainWindow, public Observer<ModelData> {
     Q_OBJECT
 public:
-    View(ModelPtr model)
-        : pModel(model)
-        , listPage(new QWidget(this))
-    { }
-
+	View(ModelPtr model);
     void init();
-    virtual void update(void* data) override;
-    void display(const std::vector<MediaPtr>& medias);
+    virtual void update(const ModelData& data) override;
 
     
     void showEditForm(const MediaPtr& media, bool isNew);

--- a/main.cpp
+++ b/main.cpp
@@ -28,9 +28,6 @@ int main(int argc, char *argv[])
     view->init();
     controller->init();
 
-    model->registerObserver(controller.get());
-    controller->registerObserver(view.get());
-
     view->show();
     return app.exec();
 }


### PR DESCRIPTION
Refactored `Controller` to remove `Observer` and `Subject` inheritance, eliminating `notifyAll` and `update` methods. Removed `mQuery` member variable and updated `init` method to interact directly with `pModel`.

Updated `Biblioteca` to use `ModelData` struct for notifications, modifying `search` and `clear` methods to notify observers with relevant data.

Changed `Media` to inherit from `SubjectNoParameters`. Enhanced `Observer` and `Subject` templates in `Observer.h` to support parameterized notifications, including specializations for `void`.

Updated `View` to inherit from `Observer<ModelData>`, adjusting `update` method and constructor for new observer pattern. Removed observer registrations in `main.cpp`.

Overall, these changes improve code clarity and flexibility by using parameterized notifications in the observer pattern.